### PR TITLE
add name to metadata so it works with Policyfiles

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,8 +1,9 @@
+name 'deployer'
 maintainer 'Seth Vargo'
 maintainer_email 'sethvargo@gmail.com'
 license 'All rights reserved'
 description 'Installs/Configures a deployment user'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.1'
+version '0.1.2'
 
 depends 'sudo'


### PR DESCRIPTION
otherwise:

Policyfile.rb:
```ruby
...
cookbook "users"
cookbook "deployer"
...
```

shell:

```
$ chef install
Building policy mancave
Expanded run list: recipe[users], recipe[deployer]
Caching Cookbooks...
Installing users    4.0.3
Installing deployer 0.1.1
Installing sudo     3.1.0
Error: Failed to generate Policyfile.lock
Reason: (Chef::Exceptions::MetadataNotValid) Cookbook loaded at path(s) [/home/artm/.chefdk/cache/cookbooks/deployer-0.1.1-supermarket.chef.io] has invalid metadata: The `name' attribute is required in cookbook metadata
```